### PR TITLE
Eliminar config.php

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -8,4 +8,3 @@ error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE);
   // ~E_WARNING -> todos los errores excepto E_WARNING
   // ~E_NOTICE -> todos los errores excepto E_NOTICE
   // Esto para evitar que se modifique el mensjae devuleto de error
-  


### PR DESCRIPTION
Debemos eliminar el config y su datos debido a que el warning lo vamos a trabajar con el middleware de slim